### PR TITLE
Change Detail Page Button Text

### DIFF
--- a/src/templates/choropleths/detail.html
+++ b/src/templates/choropleths/detail.html
@@ -5,7 +5,7 @@
 
 {% block control-btns %}
     <a href="{% url 'choropleths:view' choropleth.pk %}">
-        <button class="btn navigate"><span class="glyphicon glyphicon-globe"></span>&nbsp;Choropleth</button>
+        <button class="btn navigate"><span class="glyphicon glyphicon-globe"></span>&nbsp;Map</button>
     </a>
 
     {% ifequal user choropleth.owner %}

--- a/src/templates/datasets/detail.html
+++ b/src/templates/datasets/detail.html
@@ -11,7 +11,7 @@
     {% block control-btns %}
         {% if dataset.has_choropleth %}
             <a href="{% url 'choropleths:view' dataset.choropleth.id %}">
-                <button class="btn navigate"> <span class="glyphicon glyphicon-globe"></span>&nbsp;Choropleth</button>
+                <button class="btn navigate"> <span class="glyphicon glyphicon-globe"></span>&nbsp;Map</button>
             </a>
         {% endif %}
 


### PR DESCRIPTION
Resolves #4.

I also change the button text on the Choropleth overview page from 'Choropleth' to 'Map'.

Screenshot so you can actually see what it looks like now.
![selection_005](https://cloud.githubusercontent.com/assets/4121849/6878478/c399cd54-d4ac-11e4-8cf8-cc133db1d159.png)
