### PR TITLE
Cache aggregate queries

### DIFF
--- a/src/datasets/api/serializers.py
+++ b/src/datasets/api/serializers.py
@@ -57,10 +57,10 @@ class DatasetSerializer(serializers.ModelSerializer):
         """
 
         return {
-            'min': obj.get_min_record(),
-            'max': obj.get_max_record(),
-            'non_zero_min': obj.get_non_zero_min_record(),
-            'non_zero_max': obj.get_non_zero_max_record()
+            'min': obj.min_record,
+            'max': obj.max_record,
+            'non_zero_min': obj.non_zero_min_record,
+            'non_zero_max': obj.non_zero_max_record
         }
 
     def get_scales_options(self, obj):

--- a/src/datasets/models.py
+++ b/src/datasets/models.py
@@ -87,6 +87,13 @@ class Dataset(PublishedMixin, AbstractNameModel):
         on_delete=models.SET_NULL
     )
 
+    def __init__(self, *args, **kwargs):
+        self._min_record = None
+        self._max_record = None
+        self._non_zero_min_record = None
+        self._non_zero_max_record = None
+        super(Dataset, self).__init__(*args, **kwargs)
+
     def get_dataset_id(self):
         """
         Double dispatch method for getting the Dataset id from the generic
@@ -114,7 +121,43 @@ class Dataset(PublishedMixin, AbstractNameModel):
         if self.has_choropleth():
             return self.choropleth.id
 
-    def get_max_record(self):
+    @property
+    def max_record(self):
+        """
+        The cached result of _get_max_record().
+        """
+        if not self._max_record:
+            self._max_record = self._get_max_record()
+        return self._max_record
+
+    @property
+    def min_record(self):
+        """
+        The cached result of _get_min_record().
+        """
+        if not self._min_record:
+            self._min_record = self._get_min_record()
+        return self._min_record
+
+    @property
+    def non_zero_max_record(self):
+        """
+        The cached result of _get_non_zero_max_record().
+        """
+        if not self._non_zero_max_record:
+            self._non_zero_max_record = self._get_non_zero_max_record()
+        return self._non_zero_max_record
+
+    @property
+    def non_zero_min_record(self):
+        """
+        The cached result of _get_non_zero_min_record().
+        """
+        if not self._non_zero_min_record:
+            self._non_zero_min_record = self._get_non_zero_min_record()
+        return self._non_zero_min_record
+
+    def _get_max_record(self):
         """
         Maximum Record:
 
@@ -124,7 +167,7 @@ class Dataset(PublishedMixin, AbstractNameModel):
             max_value = self.records.all().aggregate(models.Max('value'))
             return max_value['value__max']
 
-    def get_non_zero_max_record(self):
+    def _get_non_zero_max_record(self):
         """
         Maximum Non-zero Record
 
@@ -136,9 +179,9 @@ class Dataset(PublishedMixin, AbstractNameModel):
                             .exclude(value=None) \
                             .aggregate(models.Max('value'))
             return max_value['value__max']
-        return self.get_max_record()
+        return self.max_record
 
-    def get_min_record(self):
+    def _get_min_record(self):
         """
         Minimum Record:
 
@@ -148,7 +191,7 @@ class Dataset(PublishedMixin, AbstractNameModel):
             min_value = self.records.all().aggregate(models.Min('value'))
             return min_value['value__min']
 
-    def get_non_zero_min_record(self):
+    def _get_non_zero_min_record(self):
         """
         Minimum Non-zero Record
 
@@ -160,7 +203,7 @@ class Dataset(PublishedMixin, AbstractNameModel):
                             .exclude(value=None) \
                             .aggregate(models.Min('value'))
             return min_value['value__min']
-        return self.get_min_record()
+        return self.min_record
 
     def domain_contains_zero(self):
         """
@@ -170,8 +213,8 @@ class Dataset(PublishedMixin, AbstractNameModel):
         The domain is the interval created by the the Min record value and the
         Max record value
         """
-        min_value = self.get_min_record()
-        max_value = self.get_max_record()
+        min_value = self.min_record
+        max_value = self.max_record
 
         return min_value <= 0 <= max_value
 
@@ -191,8 +234,8 @@ class Dataset(PublishedMixin, AbstractNameModel):
         the min and max of the dataset
         """
         scales = [SCALE_CHOICES[0]]
-        min_value = self.get_min_record()
-        max_value = self.get_max_record()
+        min_value = self.min_record
+        max_value = self.max_record
 
         if self.domain_contains_zero():
             # Don't include Logarithmic scale if both values are zero

--- a/src/datasets/models.py
+++ b/src/datasets/models.py
@@ -164,7 +164,7 @@ class Dataset(PublishedMixin, AbstractNameModel):
         Used to determine the domain of the dataset
         """
         if self.records.exists():
-            max_value = self.records.all().aggregate(models.Max('value'))
+            max_value = self.records.aggregate(models.Max('value'))
             return max_value['value__max']
 
     def _get_non_zero_max_record(self):
@@ -188,7 +188,7 @@ class Dataset(PublishedMixin, AbstractNameModel):
         Used to determine the domain of the dataset
         """
         if self.records.exists():
-            min_value = self.records.all().aggregate(models.Min('value'))
+            min_value = self.records.aggregate(models.Min('value'))
             return min_value['value__min']
 
     def _get_non_zero_min_record(self):

--- a/src/datasets/tests.py
+++ b/src/datasets/tests.py
@@ -169,7 +169,7 @@ class DatasetTestCase(TestCase):
             self.dataset.min_record
 
     def test_non_zero_max_record_executes_queries_once(self):
-        # Go ahead and cache the resules of these operations
+        # Go ahead and cache the results of these operations
         # because non_zero_max_record will use these to check
         # if the dataset is positive.
         self.zero_dataset.max_record
@@ -186,9 +186,7 @@ class DatasetTestCase(TestCase):
             self.zero_dataset.non_zero_max_record
 
     def test_non_zero_min_record_executes_queries_once(self):
-        # Go ahead and cache the resules of these operations
-        # because non_zero_min_record will use these to check
-        # if the dataset is positive.
+        # See test_non_zero_max_record_executes_queries_once.
         self.zero_dataset.min_record
         self.zero_dataset.max_record
 

--- a/src/datasets/tests.py
+++ b/src/datasets/tests.py
@@ -149,9 +149,14 @@ class DatasetTestCase(TestCase):
         self.assertEqual(int(self.dataset.max_record), 10)
 
     def test_max_record_executes_queries_once(self):
-        # The max_record property will execute exactly 2 queries
-        # the first time it is called. The first to get the related record,
-        # and the second to get the aggregation.
+        """
+        The max_record property will execute exactly 2 queries
+        the first time it is called. The first to get the related record,
+        and the second to get the aggregation.
+
+        The property is accessed four times, but the queries are only
+        executed on the first call.
+        """
         with self.assertNumQueries(2):
             self.dataset.max_record
             self.dataset.max_record
@@ -159,9 +164,14 @@ class DatasetTestCase(TestCase):
             self.dataset.max_record
 
     def test_min_record_executes_queries_once(self):
-        # The min_record property will execute exactly 2 queries
-        # the first time it is called. The first to get the related record,
-        # and the second to get the aggregation.
+        """
+        The min_record property will execute exactly 2 queries
+        the first time it is called. The first to get the related record,
+        and the second to get the aggregation.
+
+        The property is accessed four times, but the queries are only
+        executed on the first call.
+        """
         with self.assertNumQueries(2):
             self.dataset.min_record
             self.dataset.min_record
@@ -169,6 +179,10 @@ class DatasetTestCase(TestCase):
             self.dataset.min_record
 
     def test_non_zero_max_record_executes_queries_once(self):
+        """
+        The property is accessed eight times, but the queries are only
+        executed on the first call.
+        """
         # Go ahead and cache the results of these operations
         # because non_zero_max_record will use these to check
         # if the dataset is positive.
@@ -186,6 +200,10 @@ class DatasetTestCase(TestCase):
             self.zero_dataset.non_zero_max_record
 
     def test_non_zero_min_record_executes_queries_once(self):
+        """
+        The property is accessed eight times, but the queries are only
+        executed on the first call.
+        """
         # See test_non_zero_max_record_executes_queries_once.
         self.zero_dataset.min_record
         self.zero_dataset.max_record

--- a/src/datasets/tests.py
+++ b/src/datasets/tests.py
@@ -113,12 +113,17 @@ class DatasetValidatorTestCase(TestCase):
 class DatasetTestCase(TestCase):
     def setUp(self):
         self.dataset = mommy.make(Dataset)
+        self.zero_dataset = mommy.make(Dataset)
         records = mommy.make(DatasetRecord, _quantity=10, value=seq(0))
+        zero_records = mommy.make(DatasetRecord, _quantity=10, value=seq(-1))
+
         for record in records:
             self.dataset.records.add(record)
 
+        for record in zero_records:
+            self.zero_dataset.records.add(record)
+
     def test_has_choropleth_is_false(self):
-        # dataset = Dataset.objects.get(name="Test")
         self.assertFalse(self.dataset.has_choropleth())
 
     def test_has_choropleth_is_true(self):
@@ -139,6 +144,95 @@ class DatasetTestCase(TestCase):
     def test__get_max_record(self):
         max_record = self.dataset._get_max_record()
         self.assertEqual(int(max_record), 10)
+
+    def test_max_record(self):
+        self.assertEqual(int(self.dataset.max_record), 10)
+
+    def test_max_record_executes_queries_once(self):
+        # The max_record property will execute exactly 2 queries
+        # the first time it is called. The first to get the related record,
+        # and the second to get the aggregation.
+        with self.assertNumQueries(2):
+            self.dataset.max_record
+            self.dataset.max_record
+            self.dataset.max_record
+            self.dataset.max_record
+
+    def test_min_record_executes_queries_once(self):
+        # The min_record property will execute exactly 2 queries
+        # the first time it is called. The first to get the related record,
+        # and the second to get the aggregation.
+        with self.assertNumQueries(2):
+            self.dataset.min_record
+            self.dataset.min_record
+            self.dataset.min_record
+            self.dataset.min_record
+
+    def test_non_zero_max_record_executes_queries_once(self):
+        # Go ahead and cache the resules of these operations
+        # because non_zero_max_record will use these to check
+        # if the dataset is positive.
+        self.zero_dataset.max_record
+        self.zero_dataset.min_record
+
+        with self.assertNumQueries(4):
+            self.zero_dataset.non_zero_max_record
+            self.zero_dataset.non_zero_max_record
+            self.zero_dataset.non_zero_max_record
+            self.zero_dataset.non_zero_max_record
+            self.zero_dataset.non_zero_max_record
+            self.zero_dataset.non_zero_max_record
+            self.zero_dataset.non_zero_max_record
+            self.zero_dataset.non_zero_max_record
+
+    def test_non_zero_min_record_executes_queries_once(self):
+        # Go ahead and cache the resules of these operations
+        # because non_zero_min_record will use these to check
+        # if the dataset is positive.
+        self.zero_dataset.min_record
+        self.zero_dataset.max_record
+
+        with self.assertNumQueries(4):
+            self.zero_dataset.non_zero_min_record
+            self.zero_dataset.non_zero_min_record
+            self.zero_dataset.non_zero_min_record
+            self.zero_dataset.non_zero_min_record
+            self.zero_dataset.non_zero_min_record
+            self.zero_dataset.non_zero_min_record
+            self.zero_dataset.non_zero_min_record
+            self.zero_dataset.non_zero_min_record
+
+    def test_max_record_equals__get_max_record(self):
+        self.assertEqual(
+            self.dataset.max_record, self.dataset._get_max_record())
+
+        self.assertEqual(
+            self.zero_dataset.max_record, self.zero_dataset._get_max_record())
+
+    def test_min_record_equals__get_min_record(self):
+        self.assertEqual(
+            self.dataset.min_record, self.dataset._get_min_record())
+
+        self.assertEqual(
+            self.zero_dataset.min_record, self.zero_dataset._get_min_record())
+
+    def test_non_zero_max_record_equals__get_non_zero_max_record(self):
+        self.assertEqual(
+            self.dataset.non_zero_max_record,
+            self.dataset._get_non_zero_max_record())
+
+        self.assertEqual(
+            self.zero_dataset.non_zero_max_record,
+            self.zero_dataset._get_non_zero_max_record())
+
+    def test_non_zero_min_record_equals__get_non_zero_min_record(self):
+        self.assertEqual(
+            self.dataset.non_zero_min_record,
+            self.dataset._get_non_zero_min_record())
+
+        self.assertEqual(
+            self.zero_dataset.non_zero_min_record,
+            self.zero_dataset._get_non_zero_min_record())
 
     def test__get_non_zero_min_record(self):
         self.dataset.records.add(mommy.make(DatasetRecord, value=0))

--- a/src/datasets/tests.py
+++ b/src/datasets/tests.py
@@ -132,29 +132,29 @@ class DatasetTestCase(TestCase):
     def test_has_records_is_true(self):
         self.assertTrue(self.dataset.has_records())
 
-    def test_get_min_record(self):
-        min_record = self.dataset.get_min_record()
+    def test__get_min_record(self):
+        min_record = self.dataset._get_min_record()
         self.assertEqual(int(min_record), 1)
 
-    def test_get_max_record(self):
-        max_record = self.dataset.get_max_record()
+    def test__get_max_record(self):
+        max_record = self.dataset._get_max_record()
         self.assertEqual(int(max_record), 10)
 
-    def test_get_non_zero_min_record(self):
+    def test__get_non_zero_min_record(self):
         self.dataset.records.add(mommy.make(DatasetRecord, value=0))
-        min_record = self.dataset.get_min_record()
-        non_zero_min_record = self.dataset.get_non_zero_min_record()
+        min_record = self.dataset._get_min_record()
+        non_zero_min_record = self.dataset._get_non_zero_min_record()
         self.assertEqual(int(min_record), 0)
         self.assertEqual(int(non_zero_min_record), 1)
 
-    def test_get_non_zero_max_record(self):
+    def test__get_non_zero_max_record(self):
         self.dataset = mommy.make(Dataset)
         value_seq = seq(1, increment_by=-1)
         records = mommy.make(DatasetRecord, _quantity=10, value=value_seq)
         for record in records:
             self.dataset.records.add(record)
-        max_record = self.dataset.get_max_record()
-        non_zero_max_record = self.dataset.get_non_zero_max_record()
+        max_record = self.dataset._get_max_record()
+        non_zero_max_record = self.dataset._get_non_zero_max_record()
         self.assertEqual(int(max_record), 0)
         self.assertEqual(int(non_zero_max_record), -1)
 


### PR DESCRIPTION
These changes are to reduce the number of queries required for the `/api/datasets/<id>` endpoint. Prior, 19 queries were executed in ~11ms. Some of the 19 were also duplicates. 

This lowers the number of queries to 9 in ~9ms.

This is also intended to possibly alleviate the issue described in #16 
